### PR TITLE
🎨 feat: showcase페이지 제작

### DIFF
--- a/src/components/showCaseComponent.html
+++ b/src/components/showCaseComponent.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>29cm-showcase component</title>
+    <title>31CM-showcase component</title>
     <link rel="icon" href="/favicon.ico" />
     <link rel="preload" as="font" href="/font/woff2/PretendardVariable.woff2" />
     <link rel="stylesheet" href="/font/pretendardvariable.css" />

--- a/src/pages/ShowCase.html
+++ b/src/pages/ShowCase.html
@@ -1,0 +1,1166 @@
+<!doctype html>
+<html lang="ko-KR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>쇼케이스 - 감도 깊은 취향 셀렉트샵 31CM</title>
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="preload" as="font" href="/font/woff2/PretendardVariable.woff2" />
+    <link rel="stylesheet" href="/font/pretendardvariable.css" />
+    <link rel="stylesheet" href="/src/pages/styles/ShowCase.css" />
+  </head>
+  <body>
+    <!-- 헤더가 들어올 영역 -->
+
+    <!-- 상단의 이미지 카드 두개 -->
+    <ul class="head-container">
+      <li class="card-container">
+        <a
+          href="/"
+          class="card-link"
+          aria-label="당신의 행복한 토요일 세터 쇼케이스 상세보기"
+        >
+          <figure class="card">
+            <img
+              src="/src/assets/images/showcase-images/satur.webp"
+              alt="세터 쇼케이스"
+            />
+            <figcaption class="card-text">
+              <h3 class="head">당신의 행복한 토요일 세터</h3>
+              <p class="event">~46%할인, 사진 후기 이벤트</p>
+              <p class="time-frame">
+                <time datetime="2025-03-14">2025.03.14.</time> ~
+                <time datetime="2025-03-27"
+                  ><span class="sr-only">2025.</span>03.27.</time
+                >
+              </p>
+            </figcaption>
+          </figure>
+        </a>
+      </li>
+
+      <li class="card-container">
+        <a
+          href="/"
+          class="card-link"
+          aria-label="서로 다른 바코드처럼, 다이닛 쇼케이스 상세보기"
+        >
+          <figure class="card">
+            <img
+              src="/src/assets/images/showcase-images/deinet.webp"
+              alt="다이닛 쇼케이스"
+            />
+            <figcaption class="card-text">
+              <h3 class="head">서로 다른 바코드처럼, 다이닛</h3>
+              <p class="event">저마다의 고유한 아이덴티티가 궁금한 우리들</p>
+              <p class="time-frame">
+                <time datetime="2025-03-14">2025.03.14.</time> ~
+                <time datetime="2025-03-27"
+                  ><span class="sr-only">2025.</span>03.27.</time
+                >
+              </p>
+            </figcaption>
+          </figure>
+        </a>
+      </li>
+    </ul>
+
+    <!-- 아래의 카드 영역  -->
+    <main>
+      <ul class="body-container">
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="봄에 찾아온 이야기 오이뮤 x 폭싹 속았수다 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/oimu.webp"
+                alt="오이뮤 x 폭싹 속았수다 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">봄에 찾아온 이야기 오이뮤 x 폭싹 속았수다</h3>
+                <p class="event">~46%할인, 사은품 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="산뜻한 색으로 채우는 봄 모머위켄드 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/momur.webp"
+                alt="모머위켄드 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">산뜻한 색으로 채우는 봄 모머위켄드</h3>
+                <p class="event">
+                  ~19%할인, 사진 후기 이벤트, 사은품 증정 이벤트
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="편안함을 더한 에센셜 24/7 시리즈 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/247.webp"
+                alt="24/7 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">편안함을 더한 에센셜 24/7 시리즈</h3>
+                <p class="event">사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="일상 속 모든 순간에 함께 나일로라 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/nylora.webp"
+                alt="나일로라 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">일상 속 모든 순간에 함께 나일로라</h3>
+                <p class="event">
+                  ~10%할인, 사은품 증정 이벤트, 사진 후기 이벤트
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="바래진 것의 재발견 도프 제이슨 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/doffjason.webp"
+                alt="도프제이슨 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">바래진 것의 재발견 도프 제이슨</h3>
+                <p class="event">~60%할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="예상 밖의 즐거움 테켓 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/tecket.webp"
+                alt="테켓 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">예상 밖의 즐거움 테켓</h3>
+                <p class="event">사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="시간을 함께하는 어나더오피스 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/anotherOff.webp"
+                alt="어나더오피스 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">시간을 함께하는 어나더오피스</h3>
+                <p class="event">~24% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="만개하는 봄 러쉬 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/lush.webp"
+                alt="러쉬 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">만개하는 봄 러쉬</h3>
+                <p class="event">사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-30"
+                    ><span class="sr-only">2025.</span>03.30.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="시간을 거슬러 기억되는 문선 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/moonsun.webp"
+                alt="문선 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">시간을 거슬러 기억되는 문선</h3>
+                <p class="event">~43% 할인, 선착순 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.14.</time> ~
+                  <time datetime="2025-03-27"
+                    ><span class="sr-only">2025.</span>03.27.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="계절의 변화와 경험 홀리선 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/horsun.webp"
+                alt="홀리선 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">계절의 변화와 경험 홀리선</h3>
+                <p class="event">~24% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="설렘을 더하는 시간 스튜디오테이블 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/studioTable.webp"
+                alt="스튜디오테이블 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">설렘을 더하는 시간 스튜디오테이블</h3>
+                <p class="event">~36% 할인, 선착순 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="찬란한 실버 시에라 디자인x프로그레스 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/sierra.webp"
+                alt="시에라 디자인x프로그레스 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">찬란한 실버 시에라 디자인x프로그레스</h3>
+                <p class="event">~30% 할인, 기간 한정 혜택, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-14">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="옷의 본질 이스트로그 퍼머넌트 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/eastloguePer.webp"
+                alt="이스트로그 퍼머넌트 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">옷의 본질 이스트로그 퍼머넌트</h3>
+                <p class="event">~50% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-13">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="클래식하고 빈티지한 무드의 봄 블루민 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/blumin.webp"
+                alt="블루민 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">클래식하고 빈티지한 무드의 봄 블루민</h3>
+                <p class="event">~15% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-13">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="밤의 흐릿한 장미들 포그던 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/fogdawn.webp"
+                alt="포그던 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">밤의 흐릿한 장미들 포그던</h3>
+                <p class="event">~19% 할인, 사은품 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-13">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="몸과 마음에 힐링이 필요한 순간 아닐로 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/anillo.webp"
+                alt="아닐로 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">몸과 마음에 힐링이 필요한 순간 아닐로</h3>
+                <p class="event">
+                  ~20% 할인, 사은품 증정 이벤트, 사진 후기 이벤트
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-13">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="빛나는 당신의 이야기 프리버07 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/friver.webp"
+                alt="프리버07 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">빛나는 당신의 이야기 프리버07</h3>
+                <p class="event">
+                  ~19% 할인, 사은품 증정 이벤트, 사진 후기 이벤트
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-13">2025.03.13.</time> ~
+                  <time datetime="2025-03-26"
+                    ><span class="sr-only">2025.</span>03.26.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="추억을 걷는 혼스비 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/honsby.webp"
+                alt="혼스비 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">추억을 걷는 혼스비</h3>
+                <p class="event">~10% 할인, 포토 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-13">2025.03.13.</time> ~
+                  <time datetime="2025-03-19"
+                    ><span class="sr-only">2025.</span>03.19.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="일상과 여행을 담는 티알브이알 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/trvr.webp"
+                alt="티알브이알 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">일상과 여행을 담는 티알브이알</h3>
+                <p class="event">
+                  ~34% 할인, 사진 후기 이벤트, 사은품 증정 이벤트
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-12">2025.03.12.</time> ~
+                  <time datetime="2025-03-25"
+                    ><span class="sr-only">2025.</span>03.25.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="봄을 맞이한 순간 드파운드 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/depound.webp"
+                alt="드파운드 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">봄을 맞이한 순간 드파운드</h3>
+                <p class="event">~60% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-12">2025.03.12.</time> ~
+                  <time datetime="2025-03-25"
+                    ><span class="sr-only">2025.</span>03.25.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="색을 찾아 떠나는 여정 시엔느 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/sienne.webp"
+                alt="시엔느 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">색을 찾아 떠나는 여정 시엔느</h3>
+                <p class="event">~5% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-12">2025.03.12.</time> ~
+                  <time datetime="2025-03-25"
+                    ><span class="sr-only">2025.</span>03.25.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="내면의 아름다움 비슬로우 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/beslow.webp"
+                alt="비슬로우 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">내면의 아름다움 비슬로우</h3>
+                <p class="event">~53% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-12">2025.03.12.</time> ~
+                  <time datetime="2025-03-25"
+                    ><span class="sr-only">2025.</span>03.25.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="봄 이야기 시눈 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/sinoon.webp"
+                alt="시눈 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">봄 이야기 시눈</h3>
+                <p class="event">~10% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11">2025.03.11.</time> ~
+                  <time datetime="2025-03-25"
+                    ><span class="sr-only">2025.</span>03.25.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="우아한 만찬, 프렌치 키친웨어 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/frenchKitchen.webp"
+                alt="프렌치 키친웨어 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">우아한 만찬, 프렌치 키친웨어</h3>
+                <p
+                  class="event"
+                  title="새로운 집에서의 첫 홈 파티! 특별한 순간을 완벽하게 빛낼
+                  사브르, 드부이에, 필리빗 키친웨어를 소개합니다."
+                >
+                  새로운 집에서의 첫 홈 파티! 특별한 순간을 완벽하게 빛낼
+                  사브르, 드부이에, 필리빗 키친웨어를 소개합니다.
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11">2025.03.11.</time> ~
+                  <time datetime="2025-03-24"
+                    ><span class="sr-only">2025.</span>03.24.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="사랑스러운 봄의 시작 이미스 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/emis.webp"
+                alt="이미스 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">사랑스러운 봄의 시작 이미스</h3>
+                <p class="event">~30% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11"
+                    ><span>END</span> 2025.03.11.</time
+                  >
+                  ~
+                  <time datetime="2025-03-17"
+                    ><span class="sr-only">2025.</span>03.17.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="나에게 주는 선물 쿠론 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/couronne.webp"
+                alt="쿠론 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">나에게 주는 선물 쿠론</h3>
+                <p class="event">~30% 할인, 선착순 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11"
+                    ><span class="d-day-badge">D-day</span> 2025.03.11.</time
+                  >
+                  ~
+                  <time datetime="2025-03-18"
+                    ><span class="sr-only">2025.</span>03.18.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="새로움을 향한 여정 이스트로그 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/eastLogue.webp"
+                alt="이스트로그 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">새로움을 향한 여정 이스트로그</h3>
+                <p class="event">~5% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11">2025.03.11.</time>
+                  ~
+                  <time datetime="2025-03-24"
+                    ><span class="sr-only">2025.</span>03.24.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="운동 열정을 더하는 에이치덱스 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/hdex.webp"
+                alt="에이치덱스 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">운동 열정을 더하는 에이치덱스</h3>
+                <p class="event">~40% 할인, 선착순 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11">2025.03.11.</time>
+                  ~
+                  <time datetime="2025-03-24"
+                    ><span class="sr-only">2025.</span>03.24.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="감각적인 봄 메종마레 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/maisonMaris.webp"
+                alt="메종마레 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">감각적인 봄 메종마레</h3>
+                <p class="event">~62% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11">2025.03.11.</time>
+                  ~
+                  <time datetime="2025-03-25"
+                    ><span class="sr-only">2025.</span>03.25.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="입는 순간 시작되는 웰니스 라이프 프론투라인 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/front2line.webp"
+                alt="프론투라인 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">
+                  입는 순간 시작되는 웰니스 라이프 프론투라인
+                </h3>
+                <p class="event">~40% 할인, 사은품 증정 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-11">2025.03.11.</time>
+                  ~
+                  <time datetime="2025-03-24"
+                    ><span class="sr-only">2025.</span>03.24.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="우아한 아름다움 이아 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/eaah.webp"
+                alt="이아 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">우아한 아름다움 이아</h3>
+                <p class="event">~20% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-24"
+                    ><span class="sr-only">2025.</span>03.24.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="기교없는 담백함 블랭크룸 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/brankroom.webp"
+                alt="블랭크룸 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">기교없는 담백함 블랭크룸</h3>
+                <p class="event">~10% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="다채로운 발레코어 슈즈 오찌 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/otz.webp"
+                alt="오찌 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">다채로운 발레코어 슈즈 오찌</h3>
+                <p class="event">~30% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="두피 장벽도 튼튼하게 퍼셀 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/purcell.webp"
+                alt="퍼셀 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">두피 장벽도 튼튼하게 퍼셀</h3>
+                <p class="event">
+                  ~45% 할인, 사은품 증정 이벤트, 사진 후기 이벤트
+                </p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="진정한 봄의 서막을 여는 무쿠앤에보니 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/ebony.webp"
+                alt="무쿠앤에보니 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">진정한 봄의 서막을 여는 무쿠앤에보니</h3>
+                <p class="event">~19% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="빛나는 우리의 일상 반로에 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/vanRohe.webp"
+                alt="반로에 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">빛나는 우리의 일상 반로에</h3>
+                <p class="event">~5% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="일상 속 특별한 여정 르아보네 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/leAbonne.webp"
+                alt="르아보네 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">일상 속 특별한 여정 르아보네</h3>
+                <p class="event">~35% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="언제 어디서든 우아하게 모헤 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/mohae.webp"
+                alt="모헤 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">언제 어디서든 우아하게 모헤</h3>
+                <p class="event">~40% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="새로운 시작을 준비하며 애프터 프레이 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/afterPray.webp"
+                alt="애프터프레이 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">새로운 시작을 준비하며 애프터 프레이</h3>
+                <p class="event">~37% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="본질적이고 편안한 조스라운지 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/josLounge.webp"
+                alt="조스라운지 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">본질적이고 편안한 조스라운지</h3>
+                <p class="event">~45% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="언제든 편안하게 오프아워 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/offHour.webp"
+                alt="오프아워 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">언제든 편안하게 오프아워</h3>
+                <p class="event">~59% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+
+        <li class="card-container">
+          <a
+            href="/"
+            class="card-link"
+            aria-label="햇살이 머무는 순간 뮤제드 쇼케이스 상세보기"
+          >
+            <figure class="card">
+              <img
+                src="/src/assets/images/showcase-images/mused.webp"
+                alt="뮤제드 쇼케이스"
+              />
+              <figcaption class="card-text">
+                <h3 class="head">햇살이 머무는 순간 뮤제드</h3>
+                <p class="event">~19% 할인, 사진 후기 이벤트</p>
+                <p class="time-frame">
+                  <time datetime="2025-03-10">2025.03.10.</time>
+                  ~
+                  <time datetime="2025-03-23"
+                    ><span class="sr-only">2025.</span>03.23.</time
+                  >
+                </p>
+              </figcaption>
+            </figure>
+          </a>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/src/pages/styles/ShowCase.css
+++ b/src/pages/styles/ShowCase.css
@@ -1,0 +1,16 @@
+@import '/src/components/styles/showCaseComponent.css';
+
+/* 본문의 내용이 두줄이상 넘어가면 말줄임표로 처리 */
+/* 말줄임표가 발생한 것들은 마우스를 올리면 전체 내용들 볼수 있도록 html파일에서 title태그로 툴팁처리 하였습니다. */
+.head,
+.event {
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 최대 표시할 줄 수 */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis; /* 말줄임표 처리 */
+}
+
+.d-day-badge {
+  color: red;
+}


### PR DESCRIPTION
- 쇼케이스 페이지를 제작하였습니다.
- 29cm페이지에 이미지 카드의 내용이 2줄이상 넘어가면 말줄음표 처리를 하게끔 되었는걸 구현하였고 29cm페이지에는 적용되어있지 않지만 내용이 다 보이지 않으면 불편한 사용자도 있을거라 생각하고 title태그를 추가하여 툴팁이 나오게 구현하였습니다.

resolves #40

## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경


## PR 체크리스트


- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 키보드로 접근가능하도록 나중에 좀 더 보완하겠습니다!

## 이슈

resolves #40 
